### PR TITLE
Don't run pkgdown in PRs

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main, master, develop]
   pull_request:
-    branches: [main, master, develop]
   release:
     types: [published]
   workflow_dispatch:


### PR DESCRIPTION
We don't want to rebuild the website during PRs, only when merging.