### PR TITLE
Fix argument name in vignette example

### DIFF
--- a/vignettes/birdscanR.Rmd
+++ b/vignettes/birdscanR.Rmd
@@ -201,7 +201,7 @@ The bat infromation is, however, included in separate tables in the SQL database
 # ===========================================================================
 dbData$echoData = reclassToBats(
   echoData = dbData$echoData,
-  batClassProbabilitiesAndMtrFactors = dbData$batProbabilitiesAndMtrFactors,
+  batProbabilitiesAndMtrFactors = dbData$batProbabilitiesAndMtrFactors,
   reclassToBatCutoff = 0.5
 )
 ```


### PR DESCRIPTION
Correct a typo in vignettes/birdscanR.Rmd: replace batClassProbabilitiesAndMtrFactors with batProbabilitiesAndMtrFactors in the reclassToBats call so the example matches the actual dbData field name.