### PR TITLE
Bump version and update vignette call

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: birdscanR
 Title: Migration Traffic Rate Calculation Package for 'Birdscan MR1' Radars
-Version: 0.3.0.9027
+Version: 0.3.0.9028
 Authors@R: c(
     person("Birgen", "Haest", , "birgen.haest@vogelwarte.ch", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-8739-6460")),

--- a/vignettes/birdscanR.Rmd
+++ b/vignettes/birdscanR.Rmd
@@ -396,7 +396,7 @@ The function `plotLongitudinalMTR()` creates a time series plot of the MTR value
 # A plot is created for each timerange
 # use format "yyyy-MM-dd hh:mm"
 # ===========================================================================
-timeRangePlot = createTimeRangePlot(timeRangeData[1], timeRangeData[2], 7)
+timeRangePlot = createTimeRangeForPlot(timeRangeData[1], timeRangeData[2], 7)
 
 # Set output path for plots
 # ===========================================================================


### PR DESCRIPTION
Increase package Version in DESCRIPTION (0.3.0.9027 -> 0.3.0.9028) and update the example in vignettes/birdscanR.Rmd to use the renamed plotting helper (createTimeRangeForPlot) instead of createTimeRangePlot.