### PR TITLE
Update installation instructions in README

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -42,8 +42,8 @@ install.packages("birdscanR")
 Or the development version from [GitHub](https://github.com/BirdScanCommunity/birdscanR):
 
 ```{r, eval = FALSE}
-# install.packages("devtools")
-devtools::install_github("BirdScanCommunity/birdscanR")
+# install.packages("pak")
+pak::pak("BirdScanCommunity/birdscanR")
 ```
 
 


### PR DESCRIPTION
executing devtools::install_github("BirdScanCommunity/birdscanR") gives the warning: message: 

`install_github()` was deprecated in devtools 2.5.0. ℹ Please use pak::pak("user/repo") instead.